### PR TITLE
photo_link() function updated

### DIFF
--- a/utils/photograph.py
+++ b/utils/photograph.py
@@ -5,14 +5,37 @@ from loader import bot
 
 
 async def photo_link(photo: types.photo_size.PhotoSize) -> str:
-    with await photo.download(BytesIO()) as file:
-        form = aiohttp.FormData()
-        form.add_field(
-            name='file',
-            value=file,
-        )
-        async with bot.session.post('https://telegra.ph/upload', data=form) as response:
-            img_src = await response.json()
+#     New version
+# =================================================
+# aiogram version 2.18
 
-    link = 'http://telegra.ph/' + img_src[0]["src"]
+    form = aiohttp.FormData(quote_fields=False)
+    downloaded_photo = await photo.download(destination_file=BytesIO())
+    form.add_field(
+        name="file",
+        value=downloaded_photo
+    )
+
+    session = await bot.get_session()
+    response = await session.post(url="https://telegra.ph/upload", data=form)
+    json_response = await response.json()
+
+    link = 'http://telegra.ph/' + json_response[0]["src"]
     return link
+
+
+
+    
+#     Old version
+# =================================================
+#     with await photo.download(BytesIO()) as file:
+#         form = aiohttp.FormData()
+#         form.add_field(
+#             name='file',
+#             value=file,
+#         )
+#         async with bot.session.post('https://telegra.ph/upload', data=form) as response:
+#             img_src = await response.json()
+
+#     link = 'http://telegra.ph/' + img_src[0]["src"]
+#     return link


### PR DESCRIPTION
Bugs fixed

C:\Users\User\.....\....\aiogram\types\mixins.py:40: DeprecationWarning: destination parameter is deprecated, please use destination_dir or destination_file.
  warn_deprecated(
telegraph.py:  DeprecationWarning: Call to deprecated function session (Client session should be created inside async function, use await bot.get_session() instead).
  async with bot.session.post('https://telegra.ph/upload', data=form) as response: